### PR TITLE
SPI definition for IMU in Scala

### DIFF
--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ADIS16448.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ADIS16448.scala
@@ -1,0 +1,21 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+/**
+  * Created by Nikash on 1/14/2017.
+  *
+  * An interface for communicating with the ADIS16448 IMU.
+  */
+
+class ADIS16448 extends DigitalGyro {
+
+
+  private val imuCom: ADIS16448Protocol = new ADIS16448Protocol
+  @Override
+
+  /**
+    * Retrieves 3-dimensional data from the gyro
+    */
+  def retrieveVelocity(): Value3D = {
+    imuCom.currentData.gyro
+  }
+}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ADIS16448Protocol.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ADIS16448Protocol.scala
@@ -1,0 +1,80 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+import java.nio.ByteBuffer
+import edu.wpi.first.wpilibj.SPI
+
+/**
+  * Created by Nikash on 1/14/2017.
+  *
+  * Implements the IMU protocol for the robot.
+  */
+class ADIS16448Protocol {
+  private object Registers {
+    // List of register addresses on the IMU
+    final val SMPL_PRD: IMURegister = IMURegister(0x36)
+    final val SENS_AVG: IMURegister = IMURegister(0x38)
+    final val MSC_CTRL: IMURegister = IMURegister(0x34)
+    final val PROD_ID: IMURegister = IMURegister(0x56)
+
+  }
+    // Private object used to substitute for private values in Java
+   private object ADIS16448Protocol {
+     final val X_GYRO_REG: Byte = 0x04
+     final val Y_GYRO_REG: Byte = 0x06
+     final val Z_GYRO_REG: Byte = 0x08
+   }
+
+    // Private object used to substitute for private values in Java
+    // Contains gyro- specific constants, should be unchanged for new robot
+    // LSB: Least Significant Bits
+  private object Constants {
+    final val DegreePerSecondPerLSB: Double = 1.0 / 25.0
+    final val GPerLSB: Double = 1.0 / 1200.0
+    final val MilligaussPerLSB: Double = 1.0 / 7.0
+  }
+    //
+  private val spi: ConstantBufferSPI = new ConstantBufferSPI(SPI.Port.kMXP, 2)
+  spi.setClockRate(3000000)
+  spi.setMSBFirst()
+  spi.setSampleDataOnFalling()
+  spi.setClockActiveLow()
+  spi.setChipSelectActiveLow()
+
+  Registers.PROD_ID.read(spi)
+
+    // Checks whether or not the IMU connected uses the 16448 SPI
+  if (Registers.PROD_ID.read(spi) != 16448) {
+    throw new IllegalStateException("The device in the MXP port is not an ADIS16448 IMU")
+  }
+    // TODO: What are Magic Numbers??
+    // Saves the SPI being used (16448) to the various registers
+  Registers.SMPL_PRD.write(1, spi) // TODO: Magic Number
+  Registers.MSC_CTRL.write(4, spi) // TODO: Magic Number
+  Registers.SENS_AVG.write(Integer.parseInt("10000000000", 2), spi) // TODO: Magic Number
+
+  private val outBuffer: ByteBuffer = ByteBuffer.allocateDirect(2)
+  private val inBuffer: ByteBuffer = ByteBuffer.allocateDirect(2)
+
+    // TODO: What is happening here?
+  private def readGyroRegister(register: Byte): Short = {
+    outBuffer.put(0, register)
+    outBuffer.put(1, 0.asInstanceOf[Byte])
+    spi.write(outBuffer, 2)
+
+    inBuffer.clear
+    spi.read(false, inBuffer, 2)
+
+    inBuffer.getShort
+  }
+
+  // Gets the current gyro, accel, and magneto data from the IMU.
+  // 2nd and 3rd parameters are null because only gyro is used.
+  def currentData: IMUValue = {
+    val gyro: Value3D = Value3D(
+      readGyroRegister(ADIS16448Protocol.X_GYRO_REG),
+      readGyroRegister(ADIS16448Protocol.Y_GYRO_REG),
+      readGyroRegister(ADIS16448Protocol.Z_GYRO_REG)
+    ).times(Constants.DegreePerSecondPerLSB)
+    IMUValue(gyro, null, null)
+  }
+}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ConstantBufferSPI.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/ConstantBufferSPI.scala
@@ -1,0 +1,30 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+import java.nio.ByteBuffer
+
+import edu.wpi.first.wpilibj.SPI
+import edu.wpi.first.wpilibj.SPI._
+import edu.wpi.first.wpilibj.hal.SPIJNI
+/**
+  * Created by Nikash on 1/15/2017.
+  *
+  * Constructs an SPI interface with constant size I/O buffer.
+  * @param port the physical SPI port
+  * @param size the max size of I/O
+  */
+class ConstantBufferSPI(port: Port, size: Int) extends SPI(port) {
+  private val sendBuffer: ByteBuffer = ByteBuffer.allocateDirect(size)
+  private val receiveBuffer: ByteBuffer= ByteBuffer.allocateDirect(size)
+  private val port1: Byte = port.value.asInstanceOf[Byte]
+
+  override final def transaction(dataToSend: Array[Byte], dataReceived: Array[Byte], size: Int): Int = {
+    sendBuffer.clear()
+    receiveBuffer.clear()
+
+    sendBuffer.put(dataToSend)
+    val resultCode: Int = SPIJNI.spiTransaction(port1, sendBuffer, receiveBuffer, size.asInstanceOf[Byte])
+    receiveBuffer.get(dataReceived)
+
+    resultCode
+  }
+}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/DigitalGyro.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/DigitalGyro.scala
@@ -1,0 +1,68 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+
+import java.util
+
+/**
+  * Created by Nikash on 1/14/2017.
+  */
+abstract class DigitalGyro {
+  final var TICK_PERIOD: Double = ??? //TODO set value based on final 2017 robot
+
+  var currentVelocity: Value3D = Value3D(0, 0, 0)
+  var currentPosition: Value3D = Value3D(0,0,0)
+
+  var currentDrift: Value3D = _
+
+  var values: util.ArrayList[Value3D] = new util.ArrayList(200)
+  var index: Int = 0
+  var calibrating: Boolean = true
+
+  // Gets the current velocity.
+  def retrieveVelocity(): Value3D
+
+  // Updates values for the drift on the axis.
+  def calibrateUpdate(): Unit ={
+    index += 1
+    currentVelocity.set(retrieveVelocity())
+    values.add(index, currentVelocity)
+
+    if(index > 200) {
+      index = 0
+    }
+  }
+
+  // Updates values for the angle on the gyro.
+  def angleUpdate(): Unit = {
+    if(calibrating) {
+      val sum: Value3D = Value3D(0,0,0)
+      values.forEach(
+        value3D => sum.plusMutable(
+          value3D.valueX,
+          value3D.valueY,
+          value3D.valueZ
+        )
+      )
+      currentDrift = sum.times(-1D / values.size())
+      values = null
+
+      calibrating = false
+    }
+
+    // Stores the value as a form of memory
+    // Modifies velocity according to drift and change in position
+    val previousVelocity: Value3D = currentVelocity
+    currentVelocity.set(retrieveVelocity().plus(currentDrift))
+    currentPosition.set(currentPosition
+      .plus(Value3D(
+        trapezoidalIntegration(currentVelocity.valueX, previousVelocity.valueX),
+        trapezoidalIntegration(currentVelocity.valueY, previousVelocity.valueY),
+        trapezoidalIntegration(currentVelocity.valueZ, previousVelocity.valueZ)
+      )))
+
+  }
+  // Defines calculations for velocity adjustments
+  private def trapezoidalIntegration(velocity: Double, previousVelocity: Double): Double = {
+    TICK_PERIOD * ((velocity + previousVelocity) / 2)
+  }
+}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/IMURegister.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/IMURegister.scala
@@ -1,0 +1,55 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+/**
+  * Import statements for SPI and code involving Bytes
+  */
+
+import java.nio.ByteBuffer
+import edu.wpi.first.wpilibj.SPI
+
+/**
+  * Created by Nikash on 1/14/2017.
+  */
+/**
+  * Represents a register on the ADIS16448 IMU.
+  */
+
+/**
+  *
+  * @param register is ID of register on IMU
+  */
+case class IMURegister(register: Int) {
+  private val readBuffer: ByteBuffer = ByteBuffer.allocateDirect(2)
+  // note that casting is not supported by Scala, so must use .asInstanceOf[]
+  // Arrays not in-built in Scala, so must be defined separately
+  private val readMessage: Array[Byte] = Array((register & 0x7f).asInstanceOf[Byte], 0.asInstanceOf[Byte])
+  private val writeMessage1: Byte = (register | 0x80).asInstanceOf[Byte]
+  private val writeMessage2: Byte = (register | 0x81).asInstanceOf[Byte]
+
+  /**
+    * Reads a value from the register.
+    * @param spi the interface to use for communication
+    * @return a single value from the register
+    */
+  def read(spi: SPI): Int = {
+    readBuffer.clear()
+    spi.write(readMessage, 2)
+    spi.read(false, readBuffer, 2)
+
+    readBuffer.getShort(0).asInstanceOf[Int] & 0xffff
+
+  }
+
+  /**
+    * Writes a single value to the register.
+    *
+    * @param value the value to write
+    * @param spi   the interface to use for communication
+    */
+
+  def write(value: Int, spi: SPI): Unit = {
+    spi.write(Array(writeMessage1, value.asInstanceOf[Byte]), 2.asInstanceOf[Byte])
+    spi.write(Array(writeMessage2, (value >> 8).asInstanceOf[Byte]), 2.asInstanceOf[Byte])
+  }
+
+}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/IMUValue.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/IMUValue.scala
@@ -1,0 +1,8 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+/**
+  * Created by Nikash on 1/14/2017.
+  *
+  * Constructs a single datapoint from the IMU.
+  */
+case class IMUValue(gyro: Value3D, accel: Value3D, magneto: Value3D) {}

--- a/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/Value3D.scala
+++ b/src/main/scala/com/lynbrookrobotics/seventeen/sensors/IMU/Value3D.scala
@@ -1,0 +1,60 @@
+package com.lynbrookrobotics.seventeen.sensors.IMU
+
+/**
+  * Created by Nikash on 1/14/2017.
+  */
+
+/**
+  * Constructs a new 3D value given X, Y, and Z axes.
+  */
+
+case class Value3D(valueX: Double, valueY: Double, valueZ: Double) {
+
+  def set(src: Value3D): Unit = {
+    valueX += src.valueX
+    valueY += src.valueY
+    valueZ += src.valueZ
+  }
+
+  /**
+    * Adds this 3D value to another one.
+    * @param toAdd the 3D value to add
+    * @return the combined 3D value
+    */
+  def plus(toAdd: Value3D): Value3D = {
+  Value3D(
+    valueX + toAdd.valueX,
+    valueY + toAdd.valueY,
+    valueZ + toAdd. valueZ
+  )
+  }
+  /**
+    * Adds the given values to each axis.
+    */
+  def plusMutable(addX: Double, addY: Double, addZ: Double): Unit = {
+    valueX += addX
+    valueY += addY
+    valueZ += addZ
+  }
+  /**
+    * Multiplies this 3D value by a scalar.
+    * @param scalar the value to multiply the axes by
+    * @return the scaled 3D value
+    */
+  def times(scalar: Double): Value3D = {
+    Value3D(
+    scalar * valueX,
+    scalar * valueY,
+    scalar * valueZ
+    )
+  }
+  /**
+    * Multiplies this 3D value by a scalar.
+    * @param scalar the value to multiply the axes by
+    */
+  def timesMutable(scalar: Double): Unit = {
+    valueX *= scalar
+    valueY *= scalar
+    valueZ *= scalar
+  }
+}


### PR DESCRIPTION
Defines SPI for IMU in Scala; ported over from 2016 code in Java. 1 constant to be defined based on final 2017 robot.

Currently coded in code-2017, intended for eventual addition to potassium.