### PR TITLE
Bump sbt-frc to 0.4.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += "Funky-Repo" at "http://team846.github.io/repo"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
-addSbtPlugin("com.lynbrookrobotics" % "sbt-frc" % "0.4.1")
+addSbtPlugin("com.lynbrookrobotics" % "sbt-frc" % "0.4.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")


### PR DESCRIPTION
Adds support for `itWorks`, `restore`, and `roboClean` tasks.